### PR TITLE
[src/Metadata.hpp] fix shadow warning

### DIFF
--- a/src/Metadata.hpp
+++ b/src/Metadata.hpp
@@ -8,7 +8,7 @@ namespace metadata {
     struct KeyValue
     {
         KeyValue(){}
-        KeyValue(const std::string &key, const std::string &value): key(key),value(value){}
+        KeyValue(const std::string &_key, const std::string &_value): key(_key),value(_value){}
         std::string key;
         std::string value;
     };
@@ -16,7 +16,7 @@ namespace metadata {
     struct InterfaceObject
     {
         InterfaceObject(){}
-        InterfaceObject(const std::string &name):name(name){}
+        InterfaceObject(const std::string &_name):name(_name){}
         std::string name;
         std::vector<KeyValue> metadata;
     };


### PR DESCRIPTION
should not harm.

the fix came up while looking at the naming of the [struct Component](https://github.com/marvin2k/tools-orogen_metadata/blob/master/src/Metadata.hpp#L24) -- which causes a warning from idl because it is a reserverd corba-keyword:

```
.../base/orogen/std/.orogen/typekit/transports/corba/stdTypes.idl:24: Warning: Identifier 'Component' clashes with CORBA 3 keyword 'component'
```

Would _struct ComponentObject_ be a good replacement?

Signed-off-by: Martin Zenzes martin.zenzes@dfki.de
