### PR TITLE
Rename struct metadata::Component

### DIFF
--- a/bindings/ruby/lib/orogen_metadata/orogen_plugin.rb
+++ b/bindings/ruby/lib/orogen_metadata/orogen_plugin.rb
@@ -65,12 +65,12 @@ module Orocos
             # Entry point for the orogen registration 
             def registered_on(task_context)
                 task_context.metadata = OroGen::MetaData.new
-                task_context.property("metadata","/metadata/Component")
+                task_context.property("metadata","/metadata/TaskContext")
             end
 
             def register_for_generation(task)
                 code = Array.new
-                code << "metadata::Component md;"
+                code << "metadata::TaskContext md;"
                 task.metadata.input_ports.each do |k,v|
                     code << "{"
                     code << "metadata::InterfaceObject io(\"#{k.to_s}\");"

--- a/bindings/ruby/lib/orogen_metadata/typelib.rb
+++ b/bindings/ruby/lib/orogen_metadata/typelib.rb
@@ -1,6 +1,6 @@
 require "orogen_metadata/metadata"
 
-Typelib.convert_to_ruby '/metadata/Component', OroGen::MetaData do |data|
+Typelib.convert_to_ruby '/metadata/TaskContext', OroGen::MetaData do |data|
     res = OroGen::MetaData.new
     data.metadata.each do |value|
         res.metadata.set(value.key,value.value)
@@ -29,7 +29,7 @@ Typelib.convert_to_ruby '/metadata/Component', OroGen::MetaData do |data|
     res
 end
 
-Typelib.convert_from_ruby OroGen::MetaData, '/metadata/Component'  do |value, typelib_type|
+Typelib.convert_from_ruby OroGen::MetaData, '/metadata/TaskContext'  do |value, typelib_type|
     sample = typelib_type.new
     kv_class = Orocos.typelib_type_for("/metadata/KeyValue")
     io_class = Orocos.typelib_type_for("/metadata/InterfaceObject")

--- a/src/Metadata.hpp
+++ b/src/Metadata.hpp
@@ -21,7 +21,7 @@ namespace metadata {
         std::vector<KeyValue> metadata;
     };
 
-    struct Component
+    struct TaskContext
     {
         std::vector<KeyValue> metadata;
         std::vector<InterfaceObject> properties;


### PR DESCRIPTION
Renaming the struct to fix the following warning:

```
.../base/orogen/std/.orogen/typekit/transports/corba/stdTypes.idl:24: Warning: Identifier 'Component' clashes with CORBA 3 keyword 'component'
```

Note: Im not inclined to any particular name, I just chose one to make the PR -- feel free to suggest better solutions ,-)

Needs this [PR](https://github.com/rock-core/base-orogen-std/pull/3)!

Signed-off-by: Martin Zenzes martin.zenzes@dfki.de
